### PR TITLE
Improve support for multi kinds and add portable kinds

### DIFF
--- a/.fobos
+++ b/.fobos
@@ -1,0 +1,238 @@
+[modes]
+modes = shared-gnu static-gnu shared-gnu-debug static-gnu-debug
+        shared-intel static-intel shared-intel-debug static-intel-debug
+        tests-gnu tests-gnu-debug
+        tests-intel tests-intel-debug
+
+[common-variables]
+$CSHARED_GNU = -cpp -c -fPIC -frealloc-lhs
+$CSHARED_INT = -cpp -c -fpic -assume realloc_lhs
+$LSHARED     = -shared
+$CSTATIC_GNU = -cpp -c -frealloc-lhs
+$CSTATIC_INT = -cpp -c -assume realloc_lhs
+$DEBUG_GNU   = -O0 -g3 -Warray-bounds -Wcharacter-truncation -Wline-truncation -Wimplicit-interface -Wimplicit-procedure -Wunderflow -fcheck=all -fmodule-private -ffree-line-length-132 -fimplicit-none -fbacktrace -fdump-core -finit-real=nan -std=f2008 -fall-intrinsics
+$DEBUG_INT   = -O0 -debug all -check all -warn all -extend-source 132 -traceback -gen-interfaces#-fpe-all=0 -fp-stack-check -fstack-protector-all -ftrapuv -no-ftz -std08
+$OPTIMIZE    = -O2
+$EXDIRS      =
+
+# main modes
+# GNU
+[shared-gnu]
+template  = template-shared-gnu
+target    = fortran_tester.f90
+build_dir = ./shared/
+output    = libfortran_tester.so
+mklib     = shared
+
+[static-gnu]
+template  = template-static-gnu
+target    = fortran_tester.f90
+build_dir = ./static/
+output    = libfortran_tester.a
+mklib     = static
+
+[shared-gnu-debug]
+template  = template-shared-gnu-debug
+target    = fortran_tester.f90
+build_dir = ./shared/
+output    = libfortran_tester.so
+mklib     = shared
+
+[static-gnu-debug]
+template  = template-static-gnu-debug
+target    = fortran_tester.f90
+build_dir = ./static/
+output    = libfortran_tester.a
+mklib     = static
+
+[tests-gnu]
+template  = template-static-gnu
+build_dir = ./exe/
+
+[tests-gnu-debug]
+template  = template-static-gnu-debug
+build_dir = ./exe/
+
+# Intel
+[shared-intel]
+template  = template-shared-intel
+target    = fortran_tester.f90
+build_dir = ./shared/
+output    = libfortran_tester.so
+mklib     = shared
+
+[static-intel]
+template  = template-static-intel
+target    = fortran_tester.f90
+build_dir = ./static/
+output    = libfortran_tester.a
+mklib     = static
+
+[shared-intel-debug]
+template  = template-shared-intel-debug
+target    = fortran_tester.f90
+build_dir = ./shared/
+output    = libfortran_tester.so
+mklib     = shared
+
+[static-intel-debug]
+template  = template-static-intel-debug
+target    = fortran_tester.f90
+build_dir = ./static/
+output    = libfortran_tester.a
+mklib     = static
+
+[tests-intel]
+template = template-static-intel
+build_dir = ./exe/
+
+[tests-intel-debug]
+template  = template-static-intel-debug
+build_dir = ./exe/
+
+#templates
+[template-shared-gnu]
+compiler     = gnu
+cflags       = $CSHARED_GNU $OPTIMIZE
+lflags       = $LSHARED $OPTIMIZE
+exclude_dirs = $EXDIRS
+mod_dir      = ./mod/
+obj_dir      = ./obj/
+src          = ./
+colors       = True
+quiet        = False
+log          = True
+jobs         = 2
+
+[template-static-gnu]
+compiler     = gnu
+cflags       = $CSTATIC_GNU $OPTIMIZE
+exclude_dirs = $EXDIRS
+mod_dir      = ./mod/
+obj_dir      = ./obj/
+src          = ./
+colors       = True
+quiet        = False
+log          = True
+jobs         = 2
+
+[template-shared-gnu-debug]
+compiler     = gnu
+cflags       = $CSHARED_GNU $DEBUG_GNU
+lflags       = $LSHARED $DEBUG_GNU
+exclude_dirs = $EXDIRS
+mod_dir      = ./mod/
+obj_dir      = ./obj/
+src          = ./
+colors       = True
+quiet        = False
+log          = True
+jobs         = 2
+
+[template-static-gnu-debug]
+compiler     = gnu
+cflags       = $CSTATIC_GNU $DEBUG_GNU
+lflags       = $DEBUG_GNU
+exclude_dirs = $EXDIRS
+mod_dir      = ./mod/
+obj_dir      = ./obj/
+src          = ./
+colors       = True
+quiet        = False
+log          = True
+jobs         = 2
+
+[template-shared-intel]
+compiler     = intel
+cflags       = $CSHARED_INT $OPTIMIZE
+lflags       = $LSHARED $OPTIMIZE
+exclude_dirs = $EXDIRS
+mod_dir      = ./mod/
+obj_dir      = ./obj/
+src          = ./
+colors       = True
+quiet        = False
+log          = True
+jobs         = 2
+
+[template-static-intel]
+compiler     = intel
+cflags       = $CSTATIC_INT $OPTIMIZE
+lflags       = $OPTIMIZE
+exclude_dirs = $EXDIRS
+mod_dir      = ./mod/
+obj_dir      = ./obj/
+src          = ./
+colors       = True
+quiet        = False
+log          = True
+jobs         = 2
+
+[template-shared-intel-debug]
+compiler     = intel
+cflags       = $CSHARED_INT $DEBUG_INT
+lflags       = $LSHARED $DEBUG_INT
+exclude_dirs = $EXDIRS
+mod_dir      = ./mod/
+obj_dir      = ./obj/
+src          = ./
+colors       = True
+quiet        = False
+log          = True
+jobs         = 2
+
+[template-static-intel-debug]
+compiler     = intel
+cflags       = $CSTATIC_INT $DEBUG_INT
+lflags       = $DEBUG_INT
+exclude_dirs = $EXDIRS
+mod_dir      = ./mod/
+obj_dir      = ./obj/
+src          = ./
+colors       = True
+quiet        = False
+log          = True
+jobs         = 2
+
+# rules
+[rule-makedoc]
+help   = Build documentation from source files
+rule_1 = rm -rf doc/html/*
+rule_2 = ford doc/main_page.md --debug
+rule_3 = cp -r doc/html/publish/* doc/html/
+rule_4 = rm -rf doc/html/publish
+
+[rule-deldoc]
+help = Delete documentation
+rule = rm -rf doc/html/*
+
+[rule-delexe]
+help = Delete exes
+rule = rm -rf exe/
+
+[rule-clean]
+help = Clean the project tree
+rule_1 = FoBiS.py rule -ex deldoc
+rule_2 = FoBiS.py rule -ex delexe
+rule_3 = rm -f *.gcov
+
+[rule-maketar]
+help = Make tar archive of the project
+rule = tar --xform="s%^%fortran_tester/%" -czf fortran_tester.tar.gz *
+
+[rule-makecoverage]
+help   = Perform coverage analysis
+rule_1 = FoBiS.py clean -mode tests-gnu
+rule_2 = FoBiS.py build -mode tests-gnu -coverage
+rule_3 = ./scripts/run_tests.sh
+rule_4 = gcov -o exe/obj/ src/tester.f90
+rule_5 = rm -f *.gcov
+
+[rule-makecoverage-analysis]
+help   = Perform coverage analysis and saving reports in markdown
+rule_1 = FoBiS.py clean -mode tests-gnu
+rule_2 = FoBiS.py build -mode tests-gnu -coverage
+rule_3 = ./scripts/run_tests.sh
+rule_4 = gcov -o exe/obj/ src/tester.f90
+rule_5 = FoBiS.py rule -gcov_analyzer wiki/ Coverage-Analysis
+rule_6 = rm -f *.gcov

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 *.mod
 .DS_Store?
 /build
+doc/html
 
 test_tester

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ addons:
 env:
   global:
     - MAKECOVERAGE="./scripts/makecoverage.sh"
-    - MAKEDOC="./scripts/makedoc.sh szaghi/fortran_tester"
+    - MAKEDOC="./scripts/makedoc.sh szaghi/fortran_tester 'Stefano Zaghi' stefano.zaghi@gmail.com"
     - CLEAN=""
     - MAKETAR=""
 
@@ -47,11 +47,11 @@ install:
 
 script:
   - $MAKECOVERAGE
+  - $MAKEDOC
 
 after_success:
   # - find . -name '*.gcno' -print
   # - bash <(curl -s https://codecov.io/bash)
-  - $MAKEDOC
 
 # before_deploy:
 #   - $CLEAN

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,71 @@
+language: generic
+
+sudo: false
+
+cache:
+  apt: true
+  pip: true
+  directories:
+    - $HOME/.cache/pip
+    - $HOME/.local
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - gfortran-6
+      - binutils
+      - python-pip
+      - graphviz
+
+env:
+  global:
+    - MAKECOVERAGE="./scripts/makecoverage.sh"
+    - MAKEDOC=""
+    - CLEAN=""
+    - MAKETAR=""
+
+before_install:
+  - git submodule update --init --recursive
+
+install:
+  - |
+    if [[ ! -d "$HOME/.local/bin" ]]; then
+      mkdir "$HOME/.local/bin"
+    fi
+  - export PATH="$HOME/.local/bin:$PATH"
+  - export FC=/usr/bin/gfortran-6
+  - ln -fs /usr/bin/gfortran-6 "$HOME/.local/bin/gfortran" && gfortran --version
+  - ls -l /usr/bin/gfortran-6
+  - ln -fs /usr/bin/gcov-6 "$HOME/.local/bin/gcov" && gcov --version
+  # - pip install --user --upgrade pygooglechart
+  # - pip install --user --upgrade graphviz
+  # - pip install --user --upgrade FoBiS.py
+  # - pip install --user --upgrade markdown-checklist 
+  # - pip install --user --upgrade ford
+
+script:
+  - $MAKECOVERAGE
+
+# after_success:
+#   - find . -name '*.gcno' -print
+#   - bash <(curl -s https://codecov.io/bash)
+#   - $MAKEDOC
+
+# before_deploy:
+#   - $CLEAN
+#   - $MAKETAR
+#   - mv fortran_tester.tar.gz fortran_tester-$TRAVIS_TAG.tar.gz
+
+# deploy:
+#   provider: releases
+#   api_key:
+#     secure: 
+#   file: 
+#     - fortran_tester-$TRAVIS_TAG.tar.gz
+#     - ./scripts/install.sh
+#   skip_cleanup: true
+#   overwrite: true
+#   on:
+#     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ addons:
 env:
   global:
     - MAKECOVERAGE="./scripts/makecoverage.sh"
-    - MAKEDOC=""
+    - MAKEDOC="./scripts/makedoc.sh szaghi/fortran_tester"
     - CLEAN=""
     - MAKETAR=""
 
@@ -40,18 +40,18 @@ install:
   - ls -l /usr/bin/gfortran-6
   - ln -fs /usr/bin/gcov-6 "$HOME/.local/bin/gcov" && gcov --version
   # - pip install --user --upgrade pygooglechart
-  # - pip install --user --upgrade graphviz
+  - pip install --user --upgrade graphviz
   # - pip install --user --upgrade FoBiS.py
-  # - pip install --user --upgrade markdown-checklist 
-  # - pip install --user --upgrade ford
+  - pip install --user --upgrade markdown-checklist 
+  - pip install --user --upgrade ford
 
 script:
   - $MAKECOVERAGE
 
-# after_success:
-#   - find . -name '*.gcno' -print
-#   - bash <(curl -s https://codecov.io/bash)
-#   - $MAKEDOC
+after_success:
+  # - find . -name '*.gcno' -print
+  # - bash <(curl -s https://codecov.io/bash)
+  - $MAKEDOC
 
 # before_deploy:
 #   - $CLEAN

--- a/doc/README-fortran_tester.md
+++ b/doc/README-fortran_tester.md
@@ -1,0 +1,32 @@
+# Fortran tester
+
+`tester` is a Fortran module to test Fortran programs. It provides routines to
+check equality or closeness between variables and counting the errors.
+
+A minimal example:
+
+```fortran
+program test
+  use tester
+  implicit none
+
+  type(tester_t) :: my_tester
+
+  call my_tester% init()
+
+  call my_tester% assert_equal(1, 2, fail=.true.)
+
+  call my_tester% print()
+
+end program test
+```
+
+If none of the tests fail, the `print` method displays the message
+`fortran_tester: all tests succeeded`.
+Else, the program will exit with a nonzero error code, making it suitable for
+use as an automated test.
+
+**Author:** Pierre de Buyl  
+**License:** BSD
+
+Contributors: Peter Colberg

--- a/doc/main_page.md
+++ b/doc/main_page.md
@@ -1,0 +1,22 @@
+project: fortran_tester
+src_dir: ../src
+         ../test
+output_dir: html/publish/
+project_github: https://github.com/szaghi/fortra_tester
+summary: Fortran module to test Fortran programs
+author: Pierre de Buyl
+github: https://github.com/pdebuyl
+md_extensions: markdown.extensions.toc(anchorlink=True)
+               markdown.extensions.smarty(smart_quotes=False)
+               markdown.extensions.extra
+               markdown_checklist.extension
+docmark: <
+display: public
+         protected
+         private
+source: true
+warn: true
+graph: true
+extra_mods: iso_fortran_env:https://gcc.gnu.org/onlinedocs/gfortran/ISO_005fFORTRAN_005fENV.html
+
+{!README-fortran_tester.md!}

--- a/scripts/makecoverage.sh
+++ b/scripts/makecoverage.sh
@@ -1,0 +1,35 @@
+#!/bin/bash -
+#
+# File:        makecoverage.sh
+#
+# Description: build and perform coverage analys of fortran_tester project
+#
+# License:     GPL3+
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+
+# DEBUGGING
+set -e
+set -C # noclobber
+
+mkdir -p build
+cd build
+cmake ../
+cmake --build .
+for t in $( find ./ -type f -executable -print ); do
+  $t
+done
+cd ../

--- a/scripts/makecoverage.sh
+++ b/scripts/makecoverage.sh
@@ -4,22 +4,33 @@
 #
 # Description: build and perform coverage analys of fortran_tester project
 #
-# License:     GPL3+
+# License:     BSD
 #
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
-#
+# Copyright (C) 2015-2016 Pierre de Buyl and contributors
+
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#   a.  Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#   b. Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#   c. Neither the name of the <organization> nor the
+#      names of its contributors may be used to endorse or promote products
+#      derived from this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 # DEBUGGING
 set -e

--- a/scripts/makedoc.sh
+++ b/scripts/makedoc.sh
@@ -39,6 +39,7 @@ USEREMAIL=$3
 git config --global user.name "$USERNAME"
 git config --global user.email "$USEREMAIL"
 git clone --branch=gh-pages https://${GH_TOKEN}@github.com/$GITREPO.git doc/html
+rm -rf doc/html/*
 ford doc/main_page.md --debug
 mv doc/html/publish/* doc/html/
 rm -rf doc/html/publish/

--- a/scripts/makedoc.sh
+++ b/scripts/makedoc.sh
@@ -1,0 +1,35 @@
+#!/bin/bash -
+#
+# File:        makedoc.sh
+#
+# Description: build API html documentation of fortran_tester project
+#
+# License:     GPL3+
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+set -ev # echo what we are doing and fail on errors
+GITREPO=$1
+git config --global user.name "Stefano Zaghi"
+git config --global user.email "stefano.zaghi@gmail.com"
+git clone --branch=gh-pages https://${GH_TOKEN}@github.com/$GITREPO.git doc/html
+ford doc/main_page.md --debug
+mv doc/html/publish/* doc/html/
+rm -rf doc/html/publish/
+cd doc/html
+git add -f --all './*'
+git commit -m "Travis CI autocommit from travis build ${TRAVIS_BUILD_NUMBER}"
+git push -f origin gh-pages > /dev/null 2>&1
+cd -

--- a/scripts/makedoc.sh
+++ b/scripts/makedoc.sh
@@ -34,8 +34,10 @@
 
 set -ev # echo what we are doing and fail on errors
 GITREPO=$1
-git config --global user.name "Stefano Zaghi"
-git config --global user.email "stefano.zaghi@gmail.com"
+USERNAME=$2
+USEREMAIL=$3
+git config --global user.name "$USERNAME"
+git config --global user.email "$USEREMAIL"
 git clone --branch=gh-pages https://${GH_TOKEN}@github.com/$GITREPO.git doc/html
 ford doc/main_page.md --debug
 mv doc/html/publish/* doc/html/

--- a/scripts/makedoc.sh
+++ b/scripts/makedoc.sh
@@ -4,21 +4,33 @@
 #
 # Description: build API html documentation of fortran_tester project
 #
-# License:     GPL3+
+# License:     BSD
 #
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+# Copyright (C) 2015-2016 Pierre de Buyl and contributors
+
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#   a.  Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#   b. Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#   c. Neither the name of the <organization> nor the
+#      names of its contributors may be used to endorse or promote products
+#      derived from this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 set -ev # echo what we are doing and fail on errors
 GITREPO=$1

--- a/src/tester.f90
+++ b/src/tester.f90
@@ -4,62 +4,113 @@
 ! License: BSD
 
 module tester
+  use, intrinsic :: iso_fortran_env, only : int8, int16, int32, int64, real32, real64
+
   implicit none
   private
   public :: tester_t
 
-  type tester_t
-     integer :: n_errors
-     integer :: n_tests
-     real :: r_tol
-     double precision :: d_tol
+  type :: tester_t
+     !< The main **tester** class.
+     integer(int32) :: n_errors=0_int32                         !< Number of errors.
+     integer(int32) :: n_tests=0_int32                          !< Number of tests.
+     real(real32)   :: tolerance32=2._real32*epsilon(1._real32) !< Real tolerance, 32 bits.
+     real(real64)   :: tolerance64=2._real64*epsilon(1._real64) !< Real tolerance, 64 bits.
    contains
-     procedure :: init
-     procedure :: print
-     generic, public :: assert_equal => assert_equal_i, assert_equal_l, assert_equal_i_1, &
-          assert_equal_l_1, assert_equal_d
-     procedure, private :: assert_equal_i
-     procedure, private :: assert_equal_l
-     procedure, private :: assert_equal_i_1
-     procedure, private :: assert_equal_l_1
-     procedure, private :: assert_equal_d
-     generic, public :: assert_positive => assert_positive_i, assert_positive_i_1, assert_positive_d
-     procedure, private :: assert_positive_i
-     procedure, private :: assert_positive_i_1
-     procedure, private :: assert_positive_d
-     generic, public :: assert_close => assert_close_d, assert_close_r, assert_close_d_1
-     procedure, private :: assert_close_d
-     procedure, private :: assert_close_r
-     procedure, private :: assert_close_d_1
+     procedure :: init                           !< Initialize the tester.
+     procedure :: print                          !< Print tests results.
+     generic, public :: assert_equal =>     &
+                        assert_equal_i8,    &
+                        assert_equal_i16,   &
+                        assert_equal_i32,   &
+                        assert_equal_i64,   &
+                        assert_equal_r32,   &
+                        assert_equal_r64,   &
+                        assert_equal_l,     &
+                        assert_equal_i8_1,  &
+                        assert_equal_i16_1, &
+                        assert_equal_i32_1, &
+                        assert_equal_i64_1, &
+                        assert_equal_r32_1, &
+                        assert_equal_r64_1, &
+                        assert_equal_l_1         !< Check if two results (integer, real or logical) are equal.
+     procedure, private :: assert_equal_i8       !< Check if two integers (8  bits) are equal.
+     procedure, private :: assert_equal_i16      !< Check if two integers (16 bits) are equal.
+     procedure, private :: assert_equal_i32      !< Check if two integers (32 bits) are equal.
+     procedure, private :: assert_equal_i64      !< Check if two integers (64 bits) are equal.
+     procedure, private :: assert_equal_r32      !< Check if two reals (32 bits) are equal.
+     procedure, private :: assert_equal_r64      !< Check if two reals (64 bits) are equal.
+     procedure, private :: assert_equal_l        !< Check if two logicals are equal.
+     procedure, private :: assert_equal_i8_1     !< Check if two integer (8  bits) arrays (rank 1) are equal.
+     procedure, private :: assert_equal_i16_1    !< Check if two integer (16 bits) arrays (rank 1) are equal.
+     procedure, private :: assert_equal_i32_1    !< Check if two integer (32 bits) arrays (rank 1) are equal.
+     procedure, private :: assert_equal_i64_1    !< Check if two integer (64 bits) arrays (rank 1) are equal.
+     procedure, private :: assert_equal_r32_1    !< Check if two real (32 bits) arrays (rank 1) are equal.
+     procedure, private :: assert_equal_r64_1    !< Check if two real (64 bits) arrays (rank 1) are equal.
+     procedure, private :: assert_equal_l_1      !< Check if two logical arrays (rank 1) are equal.
+     generic, public :: assert_positive =>     &
+                        assert_positive_i8,    &
+                        assert_positive_i16,   &
+                        assert_positive_i32,   &
+                        assert_positive_i64,   &
+                        assert_positive_r32,   &
+                        assert_positive_r64,   &
+                        assert_positive_i8_1,  &
+                        assert_positive_i16_1, &
+                        assert_positive_i32_1, &
+                        assert_positive_i64_1, &
+                        assert_positive_r32_1, &
+                        assert_positive_r64_1    !< Check if a number (integer or real) is positive.
+     procedure, private :: assert_positive_i8    !< Check if a integer (8  bits) is positive.
+     procedure, private :: assert_positive_i16   !< Check if a integer (16 bits) is positive.
+     procedure, private :: assert_positive_i32   !< Check if a integer (32 bits) is positive.
+     procedure, private :: assert_positive_i64   !< Check if a integer (64 bits) is positive.
+     procedure, private :: assert_positive_r32   !< Check if a real (32 bits) is positive.
+     procedure, private :: assert_positive_r64   !< Check if a real (64 bits) is positive.
+     procedure, private :: assert_positive_i8_1  !< Check if a integer (8  bits) array (rank 1) is positive.
+     procedure, private :: assert_positive_i16_1 !< Check if a integer (16 bits) array (rank 1) is positive.
+     procedure, private :: assert_positive_i32_1 !< Check if a integer (32 bits) array (rank 1) is positive.
+     procedure, private :: assert_positive_i64_1 !< Check if a integer (64 bits) array (rank 1) is positive.
+     procedure, private :: assert_positive_r32_1 !< Check if a real (32 bits) array (rank 1) is positive.
+     procedure, private :: assert_positive_r64_1 !< Check if a real (64 bits) array (rank 1) is positive.
+     generic, public :: assert_close =>   &
+                        assert_close_r32, &
+                        assert_close_r64, &
+                        assert_close_r64_1       !< Check if two reals are close with respect a tolerance.
+     procedure, private :: assert_close_r32      !< Check if two reals (32 bits) are close with respect a tolerance.
+     procedure, private :: assert_close_r64      !< Check if two reals (64 bits) are close with respect a tolerance.
+     procedure, private :: assert_close_r64_1    !< Check if two real (64 bits) arrays (rank 1) are close with respect a tolerance.
   end type tester_t
 
 contains
 
-  subroutine init(this, d_tol, r_tol)
-    class(tester_t), intent(out) :: this
-    double precision, intent(in), optional :: d_tol
-    real, intent(in), optional :: r_tol
+  subroutine init(this, tolerance32, tolerance64)
+    !< Initialize the tester.
+    class(tester_t), intent(out)          :: this        !< The tester.
+    real(real32),    intent(in), optional :: tolerance32 !< Real tolerance, 32 bits.
+    real(real64),    intent(in), optional :: tolerance64 !< Real tolerance, 64 bits.
 
     this% n_errors = 0
     this% n_tests = 0
 
-    if (present(d_tol)) then
-       this% d_tol = d_tol
+    if (present(tolerance64)) then
+       this% tolerance64 = tolerance64
     else
-       this% d_tol = 2.d0*epsilon(1.d0)
+       this% tolerance64 = 2._real64*epsilon(1._real64)
     end if
 
-    if (present(r_tol)) then
-       this% r_tol = r_tol
+    if (present(tolerance32)) then
+       this% tolerance32 = tolerance32
     else
-       this% r_tol = 2.*epsilon(1.)
+       this% tolerance32 = 2._real32*epsilon(1._real32)
     end if
 
   end subroutine init
 
   subroutine print(this, errorstop)
-    class(tester_t), intent(in) :: this
-    logical, intent(in), optional :: errorstop
+    !< Print tests results.
+    class(tester_t), intent(in)           :: this      !< The tester.
+    logical,         intent(in), optional :: errorstop !< Flag to activate error stop if one test fails.
 
     logical :: do_errorstop
     if (present(errorstop)) then
@@ -82,10 +133,11 @@ contains
 
   end subroutine print
 
-  subroutine assert_equal_i(this, i1, i2, fail)
-    class(tester_t), intent(inout) :: this
-    integer, intent(in) :: i1, i2
-    logical, intent(in), optional :: fail
+  subroutine assert_equal_i8(this, i1, i2, fail)
+    !< Check if two integers (8 bits) are equal.
+    class(tester_t), intent(inout)        :: this   !< The tester.
+    integer(int8),   intent(in)           :: i1, i2 !< Results to be compared.
+    logical,         intent(in), optional :: fail   !< Fail flag.
 
     this% n_tests = this% n_tests + 1
     if (i1 .ne. i2) then
@@ -94,26 +146,88 @@ contains
        end if
     end if
 
-  end subroutine assert_equal_i
+  end subroutine assert_equal_i8
 
-  subroutine assert_equal_d(this, d1, d2, fail)
-    class(tester_t), intent(inout) :: this
-    double precision, intent(in) :: d1, d2
-    logical, intent(in), optional :: fail
+  subroutine assert_equal_i16(this, i1, i2, fail)
+    !< Check if two integers (16 bits) are equal.
+    class(tester_t), intent(inout)        :: this   !< The tester.
+    integer(int16),  intent(in)           :: i1, i2 !< Results to be compared.
+    logical,         intent(in), optional :: fail   !< Fail flag.
 
     this% n_tests = this% n_tests + 1
-    if (d1 .ne. d2) then
+    if (i1 .ne. i2) then
        if (.not. present(fail) .or. (present(fail) .and. fail .eqv. .false.)) then
           this% n_errors = this% n_errors + 1
        end if
     end if
 
-  end subroutine assert_equal_d
+  end subroutine assert_equal_i16
+
+  subroutine assert_equal_i32(this, i1, i2, fail)
+    !< Check if two integers (32 bits) are equal.
+    class(tester_t), intent(inout)        :: this   !< The tester.
+    integer(int32),  intent(in)           :: i1, i2 !< Results to be compared.
+    logical,         intent(in), optional :: fail   !< Fail flag.
+
+    this% n_tests = this% n_tests + 1
+    if (i1 .ne. i2) then
+       if (.not. present(fail) .or. (present(fail) .and. fail .eqv. .false.)) then
+          this% n_errors = this% n_errors + 1
+       end if
+    end if
+
+  end subroutine assert_equal_i32
+
+  subroutine assert_equal_i64(this, i1, i2, fail)
+    !< Check if two integers (64 bits) are equal.
+    class(tester_t), intent(inout)        :: this   !< The tester.
+    integer(int64),  intent(in)           :: i1, i2 !< Results to be compared.
+    logical,         intent(in), optional :: fail   !< Fail flag.
+
+    this% n_tests = this% n_tests + 1
+    if (i1 .ne. i2) then
+       if (.not. present(fail) .or. (present(fail) .and. fail .eqv. .false.)) then
+          this% n_errors = this% n_errors + 1
+       end if
+    end if
+
+  end subroutine assert_equal_i64
+
+  subroutine assert_equal_r32(this, r1, r2, fail)
+    !< Check if two reals (32 bits) are equal.
+    class(tester_t), intent(inout)        :: this   !< The tester.
+    real(real32),    intent(in)           :: r1, r2 !< Results to be compared.
+    logical,         intent(in), optional :: fail   !< Fail flag.
+
+    this% n_tests = this% n_tests + 1
+    if (r1 .ne. r2) then
+       if (.not. present(fail) .or. (present(fail) .and. fail .eqv. .false.)) then
+          this% n_errors = this% n_errors + 1
+       end if
+    end if
+
+  end subroutine assert_equal_r32
+
+  subroutine assert_equal_r64(this, r1, r2, fail)
+    !< Check if two reals (64 bits) are equal.
+    class(tester_t), intent(inout)        :: this   !< The tester.
+    real(real64),    intent(in)           :: r1, r2 !< Results to be compared.
+    logical,         intent(in), optional :: fail   !< Fail flag.
+
+    this% n_tests = this% n_tests + 1
+    if (r1 .ne. r2) then
+       if (.not. present(fail) .or. (present(fail) .and. fail .eqv. .false.)) then
+          this% n_errors = this% n_errors + 1
+       end if
+    end if
+
+  end subroutine assert_equal_r64
 
  subroutine assert_equal_l(this, l1, l2, fail)
-    class(tester_t), intent(inout) :: this
-    logical, intent(in) :: l1, l2
-    logical, intent(in), optional :: fail
+    !< Check if two logicals are equal.
+    class(tester_t), intent(inout)        :: this   !< The tester.
+    logical,         intent(in)           :: l1, l2 !< Results to be compared.
+    logical,         intent(in), optional :: fail   !< Fail flag.
 
     this% n_tests = this% n_tests + 1
     if (l1 .neqv. l2) then
@@ -124,10 +238,11 @@ contains
 
   end subroutine assert_equal_l
 
-  subroutine assert_equal_i_1(this, i1, i2, fail)
-    class(tester_t), intent(inout) :: this
-    integer, intent(in), dimension(:) :: i1, i2
-    logical, intent(in), optional :: fail
+  subroutine assert_equal_i8_1(this, i1, i2, fail)
+    !< Check if two integer (8 bits) arrays (rank 1) are equal.
+    class(tester_t),             intent(inout)        :: this   !< The tester.
+    integer(int8), dimension(:), intent(in)           :: i1, i2 !< Results to be compared.
+    logical,                     intent(in), optional :: fail   !< Fail flag.
 
     this% n_tests = this% n_tests + 1
 
@@ -143,12 +258,123 @@ contains
        end if
     end if
 
-  end subroutine assert_equal_i_1
+  end subroutine assert_equal_i8_1
+
+  subroutine assert_equal_i16_1(this, i1, i2, fail)
+    !< Check if two integer (16 bits) arrays (rank 1) are equal.
+    class(tester_t),              intent(inout)        :: this   !< The tester.
+    integer(int16), dimension(:), intent(in)           :: i1, i2 !< Results to be compared.
+    logical,                      intent(in), optional :: fail   !< Fail flag.
+
+    this% n_tests = this% n_tests + 1
+
+    if ( size(i1) .ne. size(i2) ) then
+       if (.not. present(fail) .or. (present(fail) .and. fail .eqv. .false.)) then
+          this% n_errors = this% n_errors + 1
+       end if
+    else
+       if ( maxval(abs(i1-i2)) > 0 ) then
+          if (.not. present(fail) .or. (present(fail) .and. fail .eqv. .false.)) then
+             this% n_errors = this% n_errors + 1
+          end if
+       end if
+    end if
+
+  end subroutine assert_equal_i16_1
+
+  subroutine assert_equal_i32_1(this, i1, i2, fail)
+    !< Check if two integer (32 bits) arrays (rank 1) are equal.
+    class(tester_t),              intent(inout)        :: this   !< The tester.
+    integer(int32), dimension(:), intent(in)           :: i1, i2 !< Results to be compared.
+    logical,                      intent(in), optional :: fail   !< Fail flag.
+
+    this% n_tests = this% n_tests + 1
+
+    if ( size(i1) .ne. size(i2) ) then
+       if (.not. present(fail) .or. (present(fail) .and. fail .eqv. .false.)) then
+          this% n_errors = this% n_errors + 1
+       end if
+    else
+       if ( maxval(abs(i1-i2)) > 0 ) then
+          if (.not. present(fail) .or. (present(fail) .and. fail .eqv. .false.)) then
+             this% n_errors = this% n_errors + 1
+          end if
+       end if
+    end if
+
+  end subroutine assert_equal_i32_1
+
+  subroutine assert_equal_i64_1(this, i1, i2, fail)
+    !< Check if two integer (64 bits) arrays (rank 1) are equal.
+    class(tester_t),              intent(inout)        :: this   !< The tester.
+    integer(int64), dimension(:), intent(in)           :: i1, i2 !< Results to be compared.
+    logical,                      intent(in), optional :: fail   !< Fail flag.
+
+    this% n_tests = this% n_tests + 1
+
+    if ( size(i1) .ne. size(i2) ) then
+       if (.not. present(fail) .or. (present(fail) .and. fail .eqv. .false.)) then
+          this% n_errors = this% n_errors + 1
+       end if
+    else
+       if ( maxval(abs(i1-i2)) > 0 ) then
+          if (.not. present(fail) .or. (present(fail) .and. fail .eqv. .false.)) then
+             this% n_errors = this% n_errors + 1
+          end if
+       end if
+    end if
+
+  end subroutine assert_equal_i64_1
+
+  subroutine assert_equal_r32_1(this, r1, r2, fail)
+    !< Check if two real (32 bits) arrays (rank 1) are equal.
+    class(tester_t),            intent(inout)        :: this   !< The tester.
+    real(real32), dimension(:), intent(in)           :: r1, r2 !< Results to be compared.
+    logical,                    intent(in), optional :: fail   !< Fail flag.
+
+    this% n_tests = this% n_tests + 1
+
+    if ( size(r1) .ne. size(r2) ) then
+       if (.not. present(fail) .or. (present(fail) .and. fail .eqv. .false.)) then
+          this% n_errors = this% n_errors + 1
+       end if
+    else
+       if ( maxval(abs(r1-r2)) > 0 ) then
+          if (.not. present(fail) .or. (present(fail) .and. fail .eqv. .false.)) then
+             this% n_errors = this% n_errors + 1
+          end if
+       end if
+    end if
+
+  end subroutine assert_equal_r32_1
+
+  subroutine assert_equal_r64_1(this, r1, r2, fail)
+    !< Check if two real (64 bits) arrays (rank 1) are equal.
+    class(tester_t),            intent(inout)        :: this   !< The tester.
+    real(real64), dimension(:), intent(in)           :: r1, r2 !< Results to be compared.
+    logical,                    intent(in), optional :: fail   !< Fail flag.
+
+    this% n_tests = this% n_tests + 1
+
+    if ( size(r1) .ne. size(r2) ) then
+       if (.not. present(fail) .or. (present(fail) .and. fail .eqv. .false.)) then
+          this% n_errors = this% n_errors + 1
+       end if
+    else
+       if ( maxval(abs(r1-r2)) > 0 ) then
+          if (.not. present(fail) .or. (present(fail) .and. fail .eqv. .false.)) then
+             this% n_errors = this% n_errors + 1
+          end if
+       end if
+    end if
+
+  end subroutine assert_equal_r64_1
 
   subroutine assert_equal_l_1(this, l1, l2, fail)
-    class(tester_t), intent(inout) :: this
-    logical, intent(in), dimension(:) :: l1, l2
-    logical, intent(in), optional :: fail
+    !< Check if two logical arrays (rank 1) are equal.
+    class(tester_t), intent(inout)            :: this   !< The tester.
+    logical,         intent(in), dimension(:) :: l1, l2 !< Results to be compared.
+    logical,         intent(in), optional     :: fail   !< Fail flag.
 
     integer :: k
 
@@ -171,10 +397,11 @@ contains
 
   end subroutine assert_equal_l_1
 
-  subroutine assert_positive_i(this, i, fail)
-    class(tester_t), intent(inout) :: this
-    integer, intent(in) :: i
-    logical, intent(in), optional :: fail
+  subroutine assert_positive_i8(this, i, fail)
+    !< Check if a integer (32 bits) is positive.
+    class(tester_t), intent(inout)        :: this !< The tester.
+    integer(int8),   intent(in)           :: i    !< Result to be checked.
+    logical,         intent(in), optional :: fail !< Fail flag.
 
     this% n_tests = this% n_tests + 1
     if (i < 0) then
@@ -183,26 +410,88 @@ contains
        end if
     end if
 
-  end subroutine assert_positive_i
+  end subroutine assert_positive_i8
 
-  subroutine assert_positive_d(this, d, fail)
-    class(tester_t), intent(inout) :: this
-    double precision, intent(in) :: d
-    logical, intent(in), optional :: fail
+  subroutine assert_positive_i16(this, i, fail)
+    !< Check if a integer (16 bits) is positive.
+    class(tester_t), intent(inout)        :: this !< The tester.
+    integer(int16),  intent(in)           :: i    !< Result to be checked.
+    logical,         intent(in), optional :: fail !< Fail flag.
 
     this% n_tests = this% n_tests + 1
-    if (d < 0) then
+    if (i < 0) then
        if (.not. present(fail) .or. (present(fail) .and. fail .eqv. .false.)) then
           this% n_errors = this% n_errors + 1
        end if
     end if
 
-  end subroutine assert_positive_d
+  end subroutine assert_positive_i16
 
-  subroutine assert_positive_i_1(this, i, fail)
-    class(tester_t), intent(inout) :: this
-    integer, intent(in), dimension(:) :: i
-    logical, intent(in), optional :: fail
+  subroutine assert_positive_i32(this, i, fail)
+    !< Check if a integer (32 bits) is positive.
+    class(tester_t), intent(inout)        :: this !< The tester.
+    integer(int32),  intent(in)           :: i    !< Result to be checked.
+    logical,         intent(in), optional :: fail !< Fail flag.
+
+    this% n_tests = this% n_tests + 1
+    if (i < 0) then
+       if (.not. present(fail) .or. (present(fail) .and. fail .eqv. .false.)) then
+          this% n_errors = this% n_errors + 1
+       end if
+    end if
+
+  end subroutine assert_positive_i32
+
+  subroutine assert_positive_i64(this, i, fail)
+    !< Check if a integer (32 bits) is positive.
+    class(tester_t), intent(inout)        :: this !< The tester.
+    integer(int64),  intent(in)           :: i    !< Result to be checked.
+    logical,         intent(in), optional :: fail !< Fail flag.
+
+    this% n_tests = this% n_tests + 1
+    if (i < 0) then
+       if (.not. present(fail) .or. (present(fail) .and. fail .eqv. .false.)) then
+          this% n_errors = this% n_errors + 1
+       end if
+    end if
+
+  end subroutine assert_positive_i64
+
+  subroutine assert_positive_r32(this, r, fail)
+    !< Check if a real (32 bits) is positive.
+    class(tester_t), intent(inout)        :: this !< The tester.
+    real(real32),    intent(in)           :: r    !< Result to be checked.
+    logical,         intent(in), optional :: fail !< Fail flag.
+
+    this% n_tests = this% n_tests + 1
+    if (r < 0) then
+       if (.not. present(fail) .or. (present(fail) .and. fail .eqv. .false.)) then
+          this% n_errors = this% n_errors + 1
+       end if
+    end if
+
+  end subroutine assert_positive_r32
+
+  subroutine assert_positive_r64(this, r, fail)
+    !< Check if a real (64 bits) is positive.
+    class(tester_t), intent(inout)        :: this !< The tester.
+    real(real64),    intent(in)           :: r    !< Result to be checked.
+    logical,         intent(in), optional :: fail !< Fail flag.
+
+    this% n_tests = this% n_tests + 1
+    if (r < 0) then
+       if (.not. present(fail) .or. (present(fail) .and. fail .eqv. .false.)) then
+          this% n_errors = this% n_errors + 1
+       end if
+    end if
+
+  end subroutine assert_positive_r64
+
+  subroutine assert_positive_i8_1(this, i, fail)
+    !< Check if a integer (8 bits) array (rank 1) is positive.
+    class(tester_t),             intent(inout)        :: this !< The tester.
+    integer(int8), dimension(:), intent(in)           :: i    !< Result to be checked.
+    logical,                     intent(in), optional :: fail !< Fail flag.
 
     this% n_tests = this% n_tests + 1
 
@@ -212,57 +501,140 @@ contains
        end if
     end if
 
-  end subroutine assert_positive_i_1
+  end subroutine assert_positive_i8_1
 
-  subroutine assert_close_d(this, d1, d2, fail)
-    class(tester_t), intent(inout) :: this
-    double precision, intent(in) :: d1, d2
-    logical, intent(in), optional :: fail
+  subroutine assert_positive_i16_1(this, i, fail)
+    !< Check if a integer (16 bits) array (rank 1) is positive.
+    class(tester_t),              intent(inout)        :: this !< The tester.
+    integer(int16), dimension(:), intent(in)           :: i    !< Result to be checked.
+    logical,                      intent(in), optional :: fail !< Fail flag.
 
     this% n_tests = this% n_tests + 1
 
-    if ( abs(d1-d2) > this% d_tol ) then
+    if ( minval(i) < 0 ) then
        if (.not. present(fail) .or. (present(fail) .and. fail .eqv. .false.)) then
           this% n_errors = this% n_errors + 1
        end if
     end if
 
-  end subroutine assert_close_d
+  end subroutine assert_positive_i16_1
 
-  subroutine assert_close_d_1(this, d1, d2, fail)
-    class(tester_t), intent(inout) :: this
-    double precision, intent(in), dimension(:) :: d1, d2
-    logical, intent(in), optional :: fail
+  subroutine assert_positive_i32_1(this, i, fail)
+    !< Check if a integer (32 bits) array (rank 1) is positive.
+    class(tester_t),              intent(inout)        :: this !< The tester.
+    integer(int32), dimension(:), intent(in)           :: i    !< Result to be checked.
+    logical,                      intent(in), optional :: fail !< Fail flag.
 
     this% n_tests = this% n_tests + 1
 
-    if ( size(d1) .ne. size(d2) ) then
+    if ( minval(i) < 0 ) then
+       if (.not. present(fail) .or. (present(fail) .and. fail .eqv. .false.)) then
+          this% n_errors = this% n_errors + 1
+       end if
+    end if
+
+  end subroutine assert_positive_i32_1
+
+  subroutine assert_positive_i64_1(this, i, fail)
+    !< Check if a integer (64 bits) array (rank 1) is positive.
+    class(tester_t),              intent(inout)        :: this !< The tester.
+    integer(int64), dimension(:), intent(in)           :: i    !< Result to be checked.
+    logical,                      intent(in), optional :: fail !< Fail flag.
+
+    this% n_tests = this% n_tests + 1
+
+    if ( minval(i) < 0 ) then
+       if (.not. present(fail) .or. (present(fail) .and. fail .eqv. .false.)) then
+          this% n_errors = this% n_errors + 1
+       end if
+    end if
+
+  end subroutine assert_positive_i64_1
+
+  subroutine assert_positive_r32_1(this, r, fail)
+    !< Check if a real (32 bits) array (rank 1) is positive.
+    class(tester_t),            intent(inout)        :: this !< The tester.
+    real(real32), dimension(:), intent(in)           :: r    !< Result to be checked.
+    logical,                    intent(in), optional :: fail !< Fail flag.
+
+    this% n_tests = this% n_tests + 1
+
+    if ( minval(r) < 0 ) then
+       if (.not. present(fail) .or. (present(fail) .and. fail .eqv. .false.)) then
+          this% n_errors = this% n_errors + 1
+       end if
+    end if
+
+  end subroutine assert_positive_r32_1
+
+  subroutine assert_positive_r64_1(this, r, fail)
+    !< Check if a real (64 bits) array (rank 1) is positive.
+    class(tester_t),            intent(inout)        :: this !< The tester.
+    real(real64), dimension(:), intent(in)           :: r    !< Result to be checked.
+    logical,                    intent(in), optional :: fail !< Fail flag.
+
+    this% n_tests = this% n_tests + 1
+
+    if ( minval(r) < 0 ) then
+       if (.not. present(fail) .or. (present(fail) .and. fail .eqv. .false.)) then
+          this% n_errors = this% n_errors + 1
+       end if
+    end if
+
+  end subroutine assert_positive_r64_1
+
+  subroutine assert_close_r32(this, r1, r2, fail)
+    !< Check if two reals (32 bits) are close with respect a tolerance.
+    class(tester_t), intent(inout)        :: this   !< The tester.
+    real(real32),    intent(in)           :: r1, r2 !< Results to be compared.
+    logical,         intent(in), optional :: fail   !< Fail flag.
+
+    this% n_tests = this% n_tests + 1
+
+    if ( abs(r1-r2) > this% tolerance32 ) then
+       if (.not. present(fail) .or. (present(fail) .and. fail .eqv. .false.)) then
+          this% n_errors = this% n_errors + 1
+       end if
+    end if
+
+  end subroutine assert_close_r32
+
+  subroutine assert_close_r64(this, r1, r2, fail)
+    !< Check if two reals (64 bits) are close with respect a tolerance.
+    class(tester_t),  intent(inout)        :: this   !< The tester.
+    real(real64),     intent(in)           :: r1, r2 !< Results to be compared.
+    logical,          intent(in), optional :: fail   !< Fail flag.
+
+    this% n_tests = this% n_tests + 1
+
+    if ( abs(r1-r2) > this% tolerance64 ) then
+       if (.not. present(fail) .or. (present(fail) .and. fail .eqv. .false.)) then
+          this% n_errors = this% n_errors + 1
+       end if
+    end if
+
+  end subroutine assert_close_r64
+
+  subroutine assert_close_r64_1(this, r1, r2, fail)
+    !< Check if two real (64 bits) arrays (rank 1) are close with respect a tolerance.
+    class(tester_t), intent(inout)            :: this   !< The tester.
+    real(real64),    intent(in), dimension(:) :: r1, r2 !< Results to be compared.
+    logical,         intent(in), optional     :: fail   !< Fail flag.
+
+    this% n_tests = this% n_tests + 1
+
+    if ( size(r1) .ne. size(r2) ) then
        if (.not. present(fail) .or. (present(fail) .and. fail .eqv. .false.)) then
           this% n_errors = this% n_errors + 1
        end if
     else
-       if ( maxval(abs(d1-d2)) > this% d_tol ) then
+       if ( maxval(abs(r1-r2)) > this% tolerance64 ) then
           if (.not. present(fail) .or. (present(fail) .and. fail .eqv. .false.)) then
              this% n_errors = this% n_errors + 1
           end if
        end if
     end if
 
-  end subroutine assert_close_d_1
-
-  subroutine assert_close_r(this, r1, r2, fail)
-    class(tester_t), intent(inout) :: this
-    real, intent(in) :: r1, r2
-    logical, intent(in), optional :: fail
-
-    this% n_tests = this% n_tests + 1
-
-    if ( abs(r1-r2) > this% r_tol ) then
-       if (.not. present(fail) .or. (present(fail) .and. fail .eqv. .false.)) then
-          this% n_errors = this% n_errors + 1
-       end if
-    end if
-
-  end subroutine assert_close_r
+  end subroutine assert_close_r64_1
 
 end module tester

--- a/src/tester.f90
+++ b/src/tester.f90
@@ -73,12 +73,14 @@ module tester
      procedure, private :: assert_positive_i64_1 !< Check if a integer (64 bits) array (rank 1) is positive.
      procedure, private :: assert_positive_r32_1 !< Check if a real (32 bits) array (rank 1) is positive.
      procedure, private :: assert_positive_r64_1 !< Check if a real (64 bits) array (rank 1) is positive.
-     generic, public :: assert_close =>   &
-                        assert_close_r32, &
-                        assert_close_r64, &
+     generic, public :: assert_close =>     &
+                        assert_close_r32,   &
+                        assert_close_r64,   &
+                        assert_close_r32_1, &
                         assert_close_r64_1       !< Check if two reals are close with respect a tolerance.
      procedure, private :: assert_close_r32      !< Check if two reals (32 bits) are close with respect a tolerance.
      procedure, private :: assert_close_r64      !< Check if two reals (64 bits) are close with respect a tolerance.
+     procedure, private :: assert_close_r32_1    !< Check if two real (32 bits) arrays (rank 1) are close with respect a tolerance.
      procedure, private :: assert_close_r64_1    !< Check if two real (64 bits) arrays (rank 1) are close with respect a tolerance.
   end type tester_t
 
@@ -614,6 +616,28 @@ contains
     end if
 
   end subroutine assert_close_r64
+
+  subroutine assert_close_r32_1(this, r1, r2, fail)
+    !< Check if two real (32 bits) arrays (rank 1) are close with respect a tolerance.
+    class(tester_t), intent(inout)            :: this   !< The tester.
+    real(real32),    intent(in), dimension(:) :: r1, r2 !< Results to be compared.
+    logical,         intent(in), optional     :: fail   !< Fail flag.
+
+    this% n_tests = this% n_tests + 1
+
+    if ( size(r1) .ne. size(r2) ) then
+       if (.not. present(fail) .or. (present(fail) .and. fail .eqv. .false.)) then
+          this% n_errors = this% n_errors + 1
+       end if
+    else
+       if ( maxval(abs(r1-r2)) > this% tolerance64 ) then
+          if (.not. present(fail) .or. (present(fail) .and. fail .eqv. .false.)) then
+             this% n_errors = this% n_errors + 1
+          end if
+       end if
+    end if
+
+  end subroutine assert_close_r32_1
 
   subroutine assert_close_r64_1(this, r1, r2, fail)
     !< Check if two real (64 bits) arrays (rank 1) are close with respect a tolerance.


### PR DESCRIPTION
### Introduction

Dear @pdebuyl your are a _Wiseman_, I like the exploitation of dynamic dispatch, but not all kinds for both integer and real were previously supported. Moreover, there is not real support for portable kinds (real and double precision definition can mean different things on different _architectures_).

This patch adds support for all integer kinds and for 32/64 bits real kinds (128 bits will be added in future if necessary).

**Public API is fully backward compatible, only internal API has been changed.**

I have also added a complete support for rank 1 arrays that was only partial previously.
### Why

I need at least integer with 64 bits, but instead of adding only int64 support I prefer to complete the support for all kinds.
### This change addresses the need by

List of main modifications:
- minor changes:
  - add _docstrings_ to anything: this is a preliminary step to add API
    html doc;
  - initialize _tester__ members;
  - trim out `double precision` in flavor of `real(real64)`;
- major changes:
  - `assert_equal`
    - add support for integer(8/16/32/64 bits);
    - add support for real(32/64 bits);
    - add support for arrays of integer(8/16/32/64 bits);
    - add support for arrays of real(32/64 bits);
  - `assert_positive`
    - add support for integer(8/16/32/64 bits);
    - add support for real(32/64 bits);
    - add support for arrays of integer(8/16/32/64 bits);
    - add support for arrays of real(32/64 bits);
  - `assert_close`
    - add support for real(32/64 bits);
    - add support for arrays of real(32/64 bits);
### Side effects

Nothing observed. 
### TODO

Add new tests for all the new kinds introduced.
## Feel free to not accept this patch if you do not like, do not worry to offend me :smile:
