### PR TITLE
Idea: print progress

### DIFF
--- a/src/tester.f90
+++ b/src/tester.f90
@@ -26,6 +26,7 @@ module tester
    contains
      procedure :: init                           !< Initialize the tester.
      procedure :: print                          !< Print tests results.
+     procedure :: print_progress                 !< Print partial test results.
      generic, public :: assert_equal =>     &
                         assert_equal_i8,    &
                         assert_equal_i16,   &
@@ -156,6 +157,18 @@ contains
     end if
 
   end subroutine print
+
+
+  !> Print partial information on tests results. Useful to track down where a probleb occurred.
+  subroutine print_progress(this, label)
+    class(tester_t),  intent(in) :: this  !< The tester.
+    character(len=*), intent(in) :: label !< Label representing current state.
+
+
+    write(*,*) 'fortran_tester: test "', label, '" completed.'
+    write(*,*) '                Currently ', this% n_errors, ' error(s) for', this% n_tests, 'test(s)'
+
+  end subroutine print_progress
 
   !> Check if two integers (8 bits) are equal.
   subroutine assert_equal_i8(this, i1, i2, fail)

--- a/test/test_tester_1.f90
+++ b/test/test_tester_1.f90
@@ -18,6 +18,8 @@ program test_tester_1
 
   call test% assert_equal(.true., 2 > 1)
 
+  call test% print_progress("assert_equal")
+
   call test% assert_close(1.d0, (1.d0+1.d-16))
 
   call test% assert_close(1.d0, (1.d0+1.d-15), fail=.true.)
@@ -31,6 +33,8 @@ program test_tester_1
   call test% assert_close([1.d0, 2.d0], [1.d0, 2.d0, 3.d0], fail=.true.)
 
   call test% assert_close([1.d0, 2.d0], [1.d0, 2.d0])
+  
+  call test% print_progress("assert_close")
 
   call test% print()
 


### PR DESCRIPTION
This pull request is just to discuss the possibility of labelling tests and printing partial information as the test proceeds.
I see many ways of doing this, including creating and initializing a new `tester_t` variable for each test.

The main point here is having a way to identify which test failed with a label. What's your opinion?