### PR TITLE
Fix invalid target name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,15 +55,9 @@ if((main_project OR BUILD_TESTING_${PROJECT_NAME}) AND BUILD_TESTING)
 endif()
 
 # documentation
-if(main_project)
-    set(doc doc)
-else()
-    set(doc ${NAMESPACE}doc)
-endif()
-
 find_package(Doxygen QUIET)
 if(Doxygen_FOUND)
-    add_custom_target(${doc}
+    add_custom_target(doc
         COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/doc"
         COMMAND ${DOXYGEN_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/doc/doxygen_conf"
         DEPENDS ${DOXYGEN_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/doc/doxygen_conf"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,9 +55,15 @@ if((main_project OR BUILD_TESTING_${PROJECT_NAME}) AND BUILD_TESTING)
 endif()
 
 # documentation
+if(main_project)
+    set(doc doc)
+else()
+    set(doc ${PROJECT_NAME}_doc)
+endif()
+
 find_package(Doxygen QUIET)
 if(Doxygen_FOUND)
-    add_custom_target(doc
+    add_custom_target(${doc}
         COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/doc"
         COMMAND ${DOXYGEN_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/doc/doxygen_conf"
         DEPENDS ${DOXYGEN_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/doc/doxygen_conf"


### PR DESCRIPTION
Colons are not valid characters in target names, see https://cmake.org/cmake/help/latest/policy/CMP0037.html

Without this fix, configuring fails on cmake 3.18.2 with

```
CMake Error at src/third_party/fortran_tester/CMakeLists.txt:66 (add_custom_target):
  The target name "fortran_tester::doc" is reserved or not valid for certain
  CMake features, such as generator expressions, and may result in undefined
  behavior.
```